### PR TITLE
SASS-2051 - tweak to add combined status check for overseas payments

### DIFF
--- a/app/utils/StatusHelper.scala
+++ b/app/utils/StatusHelper.scala
@@ -48,7 +48,8 @@ object StatusHelper {
   }
 
   def paymentsIntoOverseasPensionsIsUpdated(prior: Option[AllPensionsData]): Boolean = {
-    prior.flatMap(_.pensionCharges.flatMap(_.pensionSchemeOverseasTransfers)).isDefined
+    prior.flatMap(_.pensionCharges.flatMap(_.pensionSchemeOverseasTransfers)).isDefined ||
+    prior.flatMap(_.pensionCharges.flatMap(_.overseasPensionContributions)).isDefined
   }
 
 }


### PR DESCRIPTION
### Description
Add extra check for overseas pensions to include both pensionSchemeOverseasTransfers and overseasPensionContributions

Add a link to the relevant story in Jira
[SASS-2051](https://jira.tools.tax.service.gov.uk/browse/SASS-2051)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [x]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [x]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [x]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [x]  Have you addressed warnings where appropriate?
- [x]  Have you rebased against the current version of main?
- [x]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [x]  Have you checked the PR Builder passes?
