### PR TITLE
SASS-2483 Move content out of form - payments into pensions

### DIFF
--- a/app/views/pensions/OneOffRASPaymentsAmountView.scala.html
+++ b/app/views/pensions/OneOffRASPaymentsAmountView.scala.html
@@ -16,18 +16,16 @@
 
 @import views.html.templates.Layout
 @import views.html.templates.helpers.Heading
-@import views.html.templates.helpers.InputRadio
 @import views.html.templates.helpers.Button
 @import views.html.templates.helpers.ErrorSummary
-@import views.html.templates.helpers.InputText
+@import views.html.templates.helpers.InputTextAlt
 
 @this(
         layout: Layout,
         heading: Heading,
         button: Button,
         formWithCsrf: FormWithCSRF,
-        inputText: InputText,
-        inputRadio: InputRadio,
+        inputText: InputTextAlt,
         govukInsetText: GovukInsetText,
         errorSummary: ErrorSummary
 )
@@ -58,18 +56,18 @@
 
     @errorSummary(form.errors.distinct)
 
+    @heading(titleForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-2")
+    @contentHtml
+
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.OneOffRASPaymentsAmountController.submit(taxYear)) {
 
         @inputText(
             form,
             id = "amount",
             name = "amount",
-            heading = titleForUse,
-            headingClasses = "govuk-!-margin-bottom-2",
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)),
-            content = Some(contentHtml),
-            hint = Some(Html(messages("common.currency.hint"))),
-            isPageHeading = false,
+            hint = Some(messages("common.currency.hint")),
+            label = titleForUse,
+            labelHidden = true,
             currency = true
         )
 

--- a/app/views/pensions/PayIntoRetirementAnnuityContractView.scala.html
+++ b/app/views/pensions/PayIntoRetirementAnnuityContractView.scala.html
@@ -17,13 +17,15 @@
 @import views.html.templates.Layout
 @import views.html.templates.helpers.ErrorSummary
 @import views.html.templates.helpers.Button
-@import views.html.templates.helpers.InputRadio
+@import views.html.templates.helpers.InputRadioAlt
 @import views.html.templates.helpers.Details
 @import views.html.templates.helpers.Link
+@import views.html.templates.helpers.Heading
 
 @this(
         layout: Layout,
-        inputRadio: InputRadio,
+        inputRadio: InputRadioAlt,
+        heading: Heading,
         formWithCsrf: FormWithCSRF,
         errorSummary: ErrorSummary,
         button: Button,
@@ -59,14 +61,15 @@
 
     @errorSummary(form.errors.distinct)
 
+    @heading(headingForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-3")
+    @contentHtml
+
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.RetirementAnnuityController.submit(taxYear)) {
         @inputRadio(
             form = form,
-            heading = headingForUse,
-            content = Some(contentHtml),
-            classes = "govuk-!-margin-bottom-4",
+            legendHeading = Some(Html(headingForUse)),
+            legendHidden = true,
             inline = true,
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString))
         )
         @details("pensions.retirementAnnuityContract.details.title", detailsHtml)
         @button()

--- a/app/views/pensions/PensionsTaxReliefNotClaimedView.scala.html
+++ b/app/views/pensions/PensionsTaxReliefNotClaimedView.scala.html
@@ -17,7 +17,7 @@
 @import views.html.templates.Layout
 @import views.html.templates.helpers.Heading
 @import views.html.templates.helpers.Link
-@import views.html.templates.helpers.InputRadio
+@import views.html.templates.helpers.InputRadioAlt
 @import views.html.templates.helpers.Button
 @import views.html.templates.helpers.ErrorSummary
 
@@ -27,7 +27,7 @@
         button: Button,
         formWithCsrf: FormWithCSRF,
         link:Link,
-        inputRadio: InputRadio,
+        inputRadio: InputRadioAlt,
         errorSummary: ErrorSummary
 )
 
@@ -40,22 +40,22 @@
     @contentHtml = {
         <p class="govuk-body">@{messages(s"pensions.pensionsTaxReliefNotClaimed.questionsInfo.${if(request.user.isAgent) "agent" else "individual"}")}</p>
         <p class="govuk-body">@{messages(s"pensions.pensionsTaxReliefNotClaimed.whereToCheck.${if(request.user.isAgent) "agent" else "individual"}")}</p>
-        <h2 class="govuk-heading-m">@{messages(s"pensions.pensionsTaxReliefNotClaimed.subHeading.${if(request.user.isAgent) "agent" else "individual"}")}</h2>
     }
-
 
 @layout(pageTitle = titleForUse, taxYear = Some(taxYear), hasErrors = hasFormErrors, isAgent = request.user.isAgent) {
 
     @errorSummary(form.errors.distinct)
 
+    @heading(titleForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-3")
+    @contentHtml
+
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.PensionsTaxReliefNotClaimedController.submit(taxYear)) {
         @inputRadio(
             form = form,
-            heading = titleForUse,
-            content = Some(contentHtml),
-            classes = "govuk-!-margin-bottom-0",
-            inline = true,
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString))
+            legendHeading = Some(Html(messages(s"pensions.pensionsTaxReliefNotClaimed.subHeading.${if(request.user.isAgent) "agent" else "individual"}"))),
+            legendHidden = false,
+            legendAsLabel = true,
+            inline = true
         )
         @button()
     }

--- a/app/views/pensions/ReliefAtSourceOneOffPaymentsView.scala.html
+++ b/app/views/pensions/ReliefAtSourceOneOffPaymentsView.scala.html
@@ -16,7 +16,7 @@
 
 @import views.html.templates.Layout
 @import views.html.templates.helpers.Heading
-@import views.html.templates.helpers.InputRadio
+@import views.html.templates.helpers.InputRadioAlt
 @import views.html.templates.helpers.Button
 @import views.html.templates.helpers.ErrorSummary
 @import utils.ViewUtils._
@@ -26,7 +26,7 @@
         heading: Heading,
         button: Button,
         formWithCsrf: FormWithCSRF,
-        inputRadio: InputRadio,
+        inputRadio: InputRadioAlt,
         errorSummary: ErrorSummary
 )
 
@@ -37,24 +37,23 @@
 @hasFormErrors = @{form.hasErrors}
 
 @contentHtml = {
-
     <p id="this-includes" class="govuk-body">@messages(s"pensions.reliefAtSourceOneOffPayments.thisIncludes.${if(request.user.isAgent) "agent" else "individual"}",
         bigDecimalCurrency(totalRASPaymentsAndTaxRelief.toString))</p>
 }
-
 
 @layout(pageTitle = titleForUse, taxYear = Some(taxYear), hasErrors = hasFormErrors, isAgent = request.user.isAgent) {
 
     @errorSummary(form.errors.distinct)
 
+    @heading(titleForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-3")
+    @contentHtml
+
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.ReliefAtSourceOneOffPaymentsController.submit(taxYear)) {
         @inputRadio(
             form = form,
-            heading = titleForUse,
-            content = Some(contentHtml),
-            classes = "govuk-!-margin-bottom-4",
+            legendHeading = Some(Html(titleForUse)),
+            legendHidden = true,
             inline = true,
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString))
         )
         @button()
     }

--- a/app/views/pensions/ReliefAtSourcePaymentsAndTaxReliefAmountView.scala.html
+++ b/app/views/pensions/ReliefAtSourcePaymentsAndTaxReliefAmountView.scala.html
@@ -16,18 +16,16 @@
 
 @import views.html.templates.Layout
 @import views.html.templates.helpers.Heading
-@import views.html.templates.helpers.InputRadio
 @import views.html.templates.helpers.Button
 @import views.html.templates.helpers.ErrorSummary
-@import views.html.templates.helpers.InputText
+@import views.html.templates.helpers.InputTextAlt
 
 @this(
         layout: Layout,
         heading: Heading,
         button: Button,
         formWithCsrf: FormWithCSRF,
-        inputText: InputText,
-        inputRadio: InputRadio,
+        inputText: InputTextAlt,
         govukInsetText: GovukInsetText,
         errorSummary: ErrorSummary
 )
@@ -58,18 +56,18 @@
 
     @errorSummary(form.errors.distinct)
 
+    @heading(titleForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-2")
+    @contentHtml
+
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.ReliefAtSourcePaymentsAndTaxReliefAmountController.submit(taxYear)) {
 
         @inputText(
             form,
             id = "amount",
             name = "amount",
-            heading = titleForUse,
-            headingClasses = "govuk-!-margin-bottom-2",
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)),
-            content = Some(contentHtml),
-            hint = Some(Html(messages("common.currency.hint"))),
-            isPageHeading = false,
+            hint = Some(messages("common.currency.hint")),
+            label = titleForUse,
+            labelHidden = true,
             currency = true
         )
 

--- a/app/views/pensions/ReliefAtSourcePensionsView.scala.html
+++ b/app/views/pensions/ReliefAtSourcePensionsView.scala.html
@@ -18,11 +18,11 @@
 @import views.html.templates.helpers.Heading
 @import views.html.templates.helpers.ErrorSummary
 @import views.html.templates.helpers.Button
-@import views.html.templates.helpers.InputRadio
+@import views.html.templates.helpers.InputRadioAlt
 
 @this(
     layout: Layout,
-    inputRadio: InputRadio,
+    inputRadio: InputRadioAlt,
     heading: Heading,
     formWithCsrf: FormWithCSRF,
     errorSummary: ErrorSummary,
@@ -43,22 +43,23 @@
     </ul>
     <p class="govuk-body">@messages(s"pensions.reliefAtSource.pensionProvider.${if(request.user.isAgent) "agent" else "individual"}")</p>
     <p class="govuk-body">@messages(s"pensions.reliefAtSource.checkProvider.${if(request.user.isAgent) "agent" else "individual"}")</p>
-
-    <h2 class="govuk-heading-m">@messages(s"pensions.reliefAtSource.h2QuestionHeader.${if(request.user.isAgent) "agent" else "individual"}")</h2>
 }
+
 @layout(pageTitle = headingAndTitleForUse, taxYear = Some(taxYear), hasErrors = hasFormErrors, isAgent = request.user.isAgent) {
 
-@errorSummary(form.errors.distinct)
+    @errorSummary(form.errors.distinct)
+
+    @heading(headingAndTitleForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-3")
+    @contentHtml
 
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.ReliefAtSourcePensionsController.submit(taxYear)) {
 
         @inputRadio(
             form = form,
-            heading = headingAndTitleForUse,
-            content = Some(contentHtml),
-            classes = "govuk-!-margin-bottom-0",
+            legendHeading = Some(Html(messages(s"pensions.reliefAtSource.h2QuestionHeader.${if(request.user.isAgent) "agent" else "individual"}"))),
+            legendHidden = false,
+            legendAsLabel = true,
             inline = true,
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString))
         )
         @button()
     }

--- a/app/views/pensions/RetirementAnnuityAmountView.scala.html
+++ b/app/views/pensions/RetirementAnnuityAmountView.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import views.html.templates.Layout
-@import views.html.templates.helpers.InputText
+@import views.html.templates.helpers.InputTextAlt
 @import views.html.templates.helpers.Heading
 @import views.html.templates.helpers.Button
 @import views.html.templates.helpers.ErrorSummary
@@ -26,7 +26,7 @@
         heading: Heading,
         button: Button,
         formWithCsrf: FormWithCSRF,
-        inputText: InputText,
+        inputText: InputTextAlt,
         errorSummary: ErrorSummary
 )
 
@@ -46,17 +46,17 @@
 
     @errorSummary(form.errors.distinct)
 
+    @heading(titleText, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-2")
+    @contentHtml
+
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.RetirementAnnuityAmountController.submit(taxYear)) {
         @inputText(
             form,
             id = "amount",
             name = "amount",
-            heading = titleText,
-            headingClasses = "govuk-!-margin-bottom-2",
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)),
-            content = Some(contentHtml),
-            hint = Some(Html(messages("common.currency.hint"))),
-            isPageHeading = false,
+            hint = Some(messages("common.currency.hint")),
+            label = titleText,
+            labelHidden = true,
             currency = true
         )
         @button()

--- a/app/views/pensions/TotalPaymentsIntoRASView.scala.html
+++ b/app/views/pensions/TotalPaymentsIntoRASView.scala.html
@@ -17,7 +17,7 @@
 @import views.html.templates.Layout
 @import views.html.templates.helpers.Heading
 @import views.html.templates.helpers.Button
-@import views.html.templates.helpers.InputRadio
+@import views.html.templates.helpers.InputRadioAlt
 @import views.html.templates.helpers.ErrorSummary
 @import views.html.templates.helpers.Table
 
@@ -27,7 +27,7 @@
         button: Button,
         table: Table,
         csrfForm: FormWithCSRF,
-        inputRadio: InputRadio,
+        inputRadio: InputRadioAlt,
         errorSummary: ErrorSummary
 )
 
@@ -62,21 +62,22 @@
         (messages("common.total"), totalRAS, "govuk-!-font-weight-bold")
     ))
 
-    <h2 class="govuk-fieldset__heading govuk-!-font-weight-bold">@messages("paymentsIntoPensions.totalRASPayments.isThisCorrect")</h2>
 }
 
 @layout(pageTitle = headingForUse, taxYear = Some(taxYear), hasErrors = hasFormErrors, isAgent = request.user.isAgent) {
 
     @errorSummary(form.errors.distinct)
 
+    @heading(headingForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-3")
+    @contentHtml
+
     @csrfForm(action = controllers.pensions.paymentsIntoPension.routes.TotalPaymentsIntoRASController.submit(taxYear)) {
         @inputRadio(
             form = form,
-            heading = headingForUse,
-            content = Some(contentHtml),
-            classes = "govuk-!-margin-bottom-4",
-            inline = true,
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString))
+            legendHeading = Some(Html(messages("paymentsIntoPensions.totalRASPayments.isThisCorrect"))),
+            legendHidden = false,
+            legendAsLabel = true,
+            inline = true
         )
 
         @button()

--- a/app/views/pensions/WorkplaceAmountView.scala.html
+++ b/app/views/pensions/WorkplaceAmountView.scala.html
@@ -17,11 +17,13 @@
 @import views.html.templates.Layout
 @import views.html.templates.helpers.ErrorSummary
 @import views.html.templates.helpers.Button
-@import views.html.templates.helpers.InputText
+@import views.html.templates.helpers.InputTextAlt
+@import views.html.templates.helpers.Heading
 
 @this(
         layout: Layout,
-        inputText: InputText,
+        heading: Heading,
+        inputText: InputTextAlt,
         formWithCsrf: FormWithCSRF,
         errorSummary: ErrorSummary,
         button: Button
@@ -61,17 +63,17 @@
 
     @errorSummary(form.errors.distinct)
 
+    @heading(headingForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-2")
+    @contentHtml
+
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.WorkplaceAmountController.submit(taxYear)) {
         @inputText(
             form,
             id = "amount",
             name = "amount",
-            heading = headingForUse,
-            headingClasses = "govuk-!-margin-bottom-2",
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)),
-            content = Some(contentHtml),
-            hint = Some(Html(messages("common.currency.hint"))),
-            isPageHeading = false,
+            hint = Some(messages("common.currency.hint")),
+            label = headingForUse,
+            labelHidden = true,
             currency = true
         )
         @button()

--- a/app/views/pensions/WorkplacePensionView.scala.html
+++ b/app/views/pensions/WorkplacePensionView.scala.html
@@ -16,7 +16,7 @@
 
 @import views.html.templates.Layout
 @import views.html.templates.helpers.Heading
-@import views.html.templates.helpers.InputRadio
+@import views.html.templates.helpers.InputRadioAlt
 @import views.html.templates.helpers.Button
 @import views.html.templates.helpers.ErrorSummary
 @import views.html.templates.helpers.Link
@@ -27,7 +27,7 @@
     heading: Heading,
     button: Button,
     formWithCsrf: FormWithCSRF,
-    inputRadio: InputRadio,
+    inputRadio: InputRadioAlt,
     errorSummary: ErrorSummary,
     link: Link
 )
@@ -54,14 +54,15 @@
 
     @errorSummary(form.errors.distinct)
 
+    @heading(titleForUse, Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString)), "govuk-!-margin-bottom-3")
+    @contentHtml
+
     @formWithCsrf(action = controllers.pensions.paymentsIntoPension.routes.WorkplacePensionController.submit(taxYear)) {
         @inputRadio(
             form = form,
-            heading = titleForUse,
-            content = Some(contentHtml),
-            classes = "govuk-!-margin-bottom-4",
+            legendHeading = Some(Html(titleForUse)),
+            legendHidden = true,
             inline = true,
-            subheading = Some(messages("common.paymentsIntoPensions.caption", (taxYear - 1).toString, taxYear.toString))
         )
         @findOutMoreLink
         @button()

--- a/app/views/templates/helpers/InputRadioAlt.scala.html
+++ b/app/views/templates/helpers/InputRadioAlt.scala.html
@@ -1,0 +1,67 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    govukRadios: GovukRadios,
+    headingHelper: Heading
+)
+
+@(
+    form: Form[_],
+    items: Seq[RadioItem] = Seq(),
+    legendHidden: Boolean = false,
+    legendAsHeading: Boolean = false,
+    legendAsLabel: Boolean = false,
+    hint: Option[Html] = None,
+    classes: Option[String] = None,
+    inline: Boolean = false,
+    name: String = "value",
+    legendHeading: Option[Html] = None
+)(implicit messages: Messages)
+
+
+@contentHtml = {
+    @legendHeading
+}
+
+@govukRadios(Radios(
+    classes = s"${if(inline){"govuk-radios--inline"}}",
+    name = name,
+    fieldset = Some(Fieldset(
+    classes = "govuk-!-margin-top-7",
+        legend = Some(Legend(
+            content = HtmlContent(contentHtml),
+            isPageHeading = legendAsHeading,
+            classes = if(legendAsHeading) "govuk-label--l" else if (legendAsLabel) "govuk-fieldset__legend--m" else if (legendHidden) "govuk-visually-hidden" else ""
+        ))
+    )),
+    hint = hint.map(hintHtml => Hint(
+        content = HtmlContent(hintHtml)
+    )),
+    items = if(items.nonEmpty) items else Seq(
+        RadioItem(id = Some("value"),
+            value = Some("true"),
+            content = Text(messages("common.yes")),
+            checked = form("value").value.contains("true")
+        ),
+        RadioItem(id = Some("value-no"),
+            value = Some("false"),
+            content = Text(messages("common.no")),
+            checked = form("value").value.contains("false")
+        )
+    ),
+    errorMessage = form(name).error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+))

--- a/app/views/templates/helpers/InputTextAlt.scala.html
+++ b/app/views/templates/helpers/InputTextAlt.scala.html
@@ -1,0 +1,57 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import utils.ViewUtils.bigDecimalCurrency
+
+@this(govukInput: GovukInput)
+
+@(
+    form: Form[_],
+    id: String,
+    name: String,
+    label: String,
+    labelHidden: Boolean = false,
+    isPageHeading: Boolean = false,
+    hint: Option[String] = None,
+    classes: Option[String] = None,
+    autocomplete: Option[String] = None,
+    inputType: String = "text",
+    currency: Boolean = false
+)(implicit messages: Messages)
+
+@govukInput(Input(
+    id,
+    name,
+    classes = if(currency) "govuk-input--width-10 " + classes.fold("")(x => x) else classes.fold("")(x => x),
+    label = Label(
+        content = Text(messages(label)),
+        isPageHeading = isPageHeading,
+        classes = if(isPageHeading) "govuk-label--l" else if (labelHidden) "govuk-visually-hidden" else ""
+    ),
+    hint = hint.map(hintKey => Hint(
+        content = HtmlContent(messages(hintKey))
+    )),
+    value = if(currency && form.errors(id).isEmpty) form(name).value.map(bigDecimalCurrency(_, "")) else form(name).value,
+    autocomplete = autocomplete.map(value => value),
+    inputType = inputType,
+    errorMessage = form(name).error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*)))),
+    prefix = if(currency) Some(PrefixOrSuffix(content = Text("£"))) else None,
+    attributes = Map("maxlength" -> "500")
+))
+
+@{
+//$COVERAGE-OFF$
+}

--- a/it/controllers/pensions/paymentsIntoPensions/OneOffRASPaymentsAmountControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/OneOffRASPaymentsAmountControllerISpec.scala
@@ -46,17 +46,16 @@ class OneOffRASPaymentsAmountControllerISpec extends IntegrationTest with ViewHe
   }
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > label > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val hintTextSelector = "#amount-hint"
     val poundPrefixSelector = ".govuk-input__prefix"
     val inputSelector = "#amount"
     val expectedErrorHref = "#amount"
-    def insetSpanText(index: Int): String = s"#main-content > div > div > form > div > label > div > span:nth-child($index)"
-    def paragraphSelector(index: Int): String = s"#main-content > div > div > form > div > label > p:nth-child($index)"
+    def insetSpanText(index: Int): String = s"#main-content > div > div > div > span:nth-child($index)"
+    def paragraphSelector(index: Int): String = s"#main-content > div > div > p:nth-of-type($index)"
   }
-
   trait CommonExpectedResults {
     val expectedCaption: Int => String
     val expectedHeading: String
@@ -160,8 +159,8 @@ class OneOffRASPaymentsAmountControllerISpec extends IntegrationTest with ViewHe
           titleCheck(expectedTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(2))
-          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(1))
+          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)
@@ -194,8 +193,8 @@ class OneOffRASPaymentsAmountControllerISpec extends IntegrationTest with ViewHe
           titleCheck(expectedTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(2))
-          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(1))
+          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)
@@ -308,8 +307,8 @@ class OneOffRASPaymentsAmountControllerISpec extends IntegrationTest with ViewHe
           titleCheck(expectedErrorTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(2))
-          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(1))
+          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)
@@ -346,8 +345,8 @@ class OneOffRASPaymentsAmountControllerISpec extends IntegrationTest with ViewHe
           titleCheck(expectedErrorTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(2))
-          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(1))
+          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)
@@ -384,8 +383,8 @@ class OneOffRASPaymentsAmountControllerISpec extends IntegrationTest with ViewHe
           titleCheck(expectedErrorTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(2))
-          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouToldUs, paragraphSelector(1))
+          textOnPageCheck(expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)

--- a/it/controllers/pensions/paymentsIntoPensions/PensionsTaxReliefNotClaimedControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/PensionsTaxReliefNotClaimedControllerISpec.scala
@@ -45,14 +45,14 @@ class PensionsTaxReliefNotClaimedControllerISpec extends IntegrationTest with Vi
   }
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > fieldset > legend > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val yesSelector = "#value"
     val noSelector = "#value-no"
-    val h2Selector: String = s"#main-content > div > div > form > div > fieldset > legend > h2"
+    val h2Selector: String = s"#main-content > div > div > form > div > fieldset > legend"
 
-    def paragraphSelector(index: Int): String = s"#main-content > div > div > form > div > fieldset > legend > p:nth-child($index)"
+    def paragraphSelector(index: Int): String = s"#main-content > div > div > p:nth-of-type($index)"
 
   }
 
@@ -154,8 +154,8 @@ class PensionsTaxReliefNotClaimedControllerISpec extends IntegrationTest with Vi
           titleCheck(expectedTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedQuestionsInfoText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedQuestionsInfoText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(2))
           textOnPageCheck(user.specificExpectedResults.get.expectedSubHeading, h2Selector)
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(false))
@@ -182,8 +182,8 @@ class PensionsTaxReliefNotClaimedControllerISpec extends IntegrationTest with Vi
           titleCheck(expectedTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedQuestionsInfoText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedQuestionsInfoText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(2))
           textOnPageCheck(user.specificExpectedResults.get.expectedSubHeading, h2Selector)
           radioButtonCheck(yesText, 1, checked = Some(true))
           radioButtonCheck(noText, 2, checked = Some(false))
@@ -212,8 +212,8 @@ class PensionsTaxReliefNotClaimedControllerISpec extends IntegrationTest with Vi
           titleCheck(expectedTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedQuestionsInfoText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedQuestionsInfoText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(2))
           textOnPageCheck(user.specificExpectedResults.get.expectedSubHeading, h2Selector)
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(true))
@@ -277,8 +277,8 @@ class PensionsTaxReliefNotClaimedControllerISpec extends IntegrationTest with Vi
           titleCheck(expectedErrorTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedQuestionsInfoText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedQuestionsInfoText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(2))
           textOnPageCheck(user.specificExpectedResults.get.expectedSubHeading, h2Selector)
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(false))

--- a/it/controllers/pensions/paymentsIntoPensions/ReliefAtSourceOneOffPaymentsControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/ReliefAtSourceOneOffPaymentsControllerISpec.scala
@@ -47,7 +47,7 @@ class ReliefAtSourceOneOffPaymentsControllerISpec extends IntegrationTest with V
   }
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > fieldset > legend > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val yesSelector = "#value"

--- a/it/controllers/pensions/paymentsIntoPensions/ReliefAtSourcePaymentsAndTaxReliefAmountControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/ReliefAtSourcePaymentsAndTaxReliefAmountControllerISpec.scala
@@ -46,15 +46,15 @@ class ReliefAtSourcePaymentsAndTaxReliefAmountControllerISpec extends Integratio
   }
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > label > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val hintTextSelector = "#amount-hint"
     val poundPrefixSelector = ".govuk-input__prefix"
     val inputSelector = "#amount"
     val expectedErrorHref = "#amount"
-    def insetSpanText(index: Int): String = s"#main-content > div > div > form > div > label > div > span:nth-child($index)"
-    def paragraphSelector(index: Int): String = s"#main-content > div > div > form > div > label > p:nth-child($index)"
+    def insetSpanText(index: Int): String = s"#main-content > div > div > div > span:nth-child($index)"
+    def paragraphSelector(index: Int): String = s"#main-content > div > div > p:nth-of-type($index)"
   }
 
   trait CommonExpectedResults {
@@ -166,8 +166,8 @@ class ReliefAtSourcePaymentsAndTaxReliefAmountControllerISpec extends Integratio
           titleCheck(expectedTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)
@@ -200,8 +200,8 @@ class ReliefAtSourcePaymentsAndTaxReliefAmountControllerISpec extends Integratio
           titleCheck(expectedTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)
@@ -301,8 +301,8 @@ class ReliefAtSourcePaymentsAndTaxReliefAmountControllerISpec extends Integratio
           titleCheck(expectedErrorTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)
@@ -339,8 +339,8 @@ class ReliefAtSourcePaymentsAndTaxReliefAmountControllerISpec extends Integratio
           titleCheck(expectedErrorTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)
@@ -377,8 +377,8 @@ class ReliefAtSourcePaymentsAndTaxReliefAmountControllerISpec extends Integratio
           titleCheck(expectedErrorTitle)
           h1Check(expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToFind, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedHowToWorkOut, paragraphSelector(2))
           textOnPageCheck(expectedCalculationHeading, insetSpanText(1))
           textOnPageCheck(expectedExampleCalculation, insetSpanText(2))
           textOnPageCheck(hintText, hintTextSelector)

--- a/it/controllers/pensions/paymentsIntoPensions/ReliefAtSourcePensionsControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/ReliefAtSourcePensionsControllerISpec.scala
@@ -37,16 +37,15 @@ class ReliefAtSourcePensionsControllerISpec extends IntegrationTest with BeforeA
   private val taxYearEOY: Int = taxYear - 1
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > fieldset > legend > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val yesSelector = "#value"
     val noSelector = "#value-no"
-    val h2Selector = "#main-content > div > div > form > div > fieldset > legend > h2"
-    val example1TextSelector = "#main-content > div > div > form > div > fieldset > legend > ul > li:nth-child(1)"
-    val example2TextSelector = "#main-content > div > div > form > div > fieldset > legend > ul > li:nth-child(2)"
-
-    def paragraphSelector(index: Int): String = s"#main-content > div > div > form > div > fieldset > legend > p:nth-child($index)"
+    val h2Selector = "#main-content > div > div > form > div > fieldset > legend"
+    val example1TextSelector = "#main-content > div > div > ul > li:nth-child(1)"
+    val example2TextSelector = "#main-content > div > div > ul > li:nth-child(2)"
+    def paragraphSelector(index: Int): String = s"#main-content > div > div > p:nth-of-type($index)"
   }
 
   trait SpecificExpectedResults {
@@ -168,11 +167,11 @@ class ReliefAtSourcePensionsControllerISpec extends IntegrationTest with BeforeA
           welshToggleCheck(user.isWelsh)
 
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedExample1, example1TextSelector)
           textOnPageCheck(user.specificExpectedResults.get.expectedExample2, example2TextSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedPensionProviderText, paragraphSelector(4))
-          textOnPageCheck(user.specificExpectedResults.get.expectedCheckProviderText, paragraphSelector(5))
+          textOnPageCheck(user.specificExpectedResults.get.expectedPensionProviderText, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedCheckProviderText, paragraphSelector(3))
         }
 
         "render 'Relief at source (RAS) pensions' page with correct content and yes pre-filled" which {
@@ -201,11 +200,11 @@ class ReliefAtSourcePensionsControllerISpec extends IntegrationTest with BeforeA
 
           textOnPageCheck(user.specificExpectedResults.get.expectedH2, h2Selector)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedExample1, example1TextSelector)
           textOnPageCheck(user.specificExpectedResults.get.expectedExample2, example2TextSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedPensionProviderText, paragraphSelector(4))
-          textOnPageCheck(user.specificExpectedResults.get.expectedCheckProviderText, paragraphSelector(5))
+          textOnPageCheck(user.specificExpectedResults.get.expectedPensionProviderText, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedCheckProviderText, paragraphSelector(3))
         }
 
         "render 'Relief at source (RAS) pensions' page with correct content and no pre-filled" which {
@@ -234,11 +233,11 @@ class ReliefAtSourcePensionsControllerISpec extends IntegrationTest with BeforeA
 
           textOnPageCheck(user.specificExpectedResults.get.expectedH2, h2Selector)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedExample1, example1TextSelector)
           textOnPageCheck(user.specificExpectedResults.get.expectedExample2, example2TextSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedPensionProviderText, paragraphSelector(4))
-          textOnPageCheck(user.specificExpectedResults.get.expectedCheckProviderText, paragraphSelector(5))
+          textOnPageCheck(user.specificExpectedResults.get.expectedPensionProviderText, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedCheckProviderText, paragraphSelector(3))
 
         }
       }
@@ -276,11 +275,11 @@ class ReliefAtSourcePensionsControllerISpec extends IntegrationTest with BeforeA
           welshToggleCheck(user.isWelsh)
 
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedExample1, example1TextSelector)
           textOnPageCheck(user.specificExpectedResults.get.expectedExample2, example2TextSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedPensionProviderText, paragraphSelector(4))
-          textOnPageCheck(user.specificExpectedResults.get.expectedCheckProviderText, paragraphSelector(5))
+          textOnPageCheck(user.specificExpectedResults.get.expectedPensionProviderText, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedCheckProviderText, paragraphSelector(3))
           errorSummaryCheck(user.specificExpectedResults.get.expectedError, yesSelector)
           errorAboveElementCheck(user.specificExpectedResults.get.expectedError, Some("value"))
         }

--- a/it/controllers/pensions/paymentsIntoPensions/RetirementAnnuityAmountControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/RetirementAnnuityAmountControllerISpec.scala
@@ -43,14 +43,14 @@ class RetirementAnnuityAmountControllerISpec extends IntegrationTest with ViewHe
   }
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > label > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val hintTextSelector = "#amount-hint"
     val poundPrefixSelector = ".govuk-input__prefix"
     val inputSelector = "#amount"
     val expectedErrorHref = "#amount"
-    val paragraphSelector: String = "#main-content > div > div > form > div > label > p"
+    val paragraphSelector: String = "#main-content > div > div > p"
   }
 
   trait CommonExpectedResults {

--- a/it/controllers/pensions/paymentsIntoPensions/RetirementAnnuityControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/RetirementAnnuityControllerISpec.scala
@@ -48,7 +48,7 @@ class RetirementAnnuityControllerISpec extends IntegrationTest with ViewHelpers 
   }
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > fieldset > legend > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val yesSelector = "#value"
@@ -57,9 +57,9 @@ class RetirementAnnuityControllerISpec extends IntegrationTest with ViewHelpers 
 
     def h3Selector(index: Int): String = s"#main-content > div > div > form > details > div > h3:nth-child($index)"
 
-    def paragraphSelector(index: Int): String = s"#main-content > div > div > form > div > fieldset > legend > p:nth-child($index)"
+    def paragraphSelector(index: Int): String = s"#main-content > div > div > p:nth-of-type($index)"
 
-    def bulletListSelector(index: Int): String = s"#main-content > div > div > form > div > fieldset > legend > ul > li:nth-child($index)"
+    def bulletListSelector(index: Int): String = s"#main-content > div > div > ul > li:nth-child($index)"
 
     def detailsParagraphSelector(index: Int): String = s"#main-content > div > div > form > details > div > p:nth-child($index)"
 
@@ -174,8 +174,8 @@ class RetirementAnnuityControllerISpec extends IntegrationTest with ViewHelpers 
           titleCheck(user.specificExpectedResults.get.expectedTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedParagraphText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedParagraphText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(false))
           buttonCheck(buttonText, continueButtonSelector)
@@ -203,8 +203,8 @@ class RetirementAnnuityControllerISpec extends IntegrationTest with ViewHelpers 
           titleCheck(user.specificExpectedResults.get.expectedTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedParagraphText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedParagraphText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           radioButtonCheck(yesText, 1, checked = Some(true))
           radioButtonCheck(noText, 2, checked = Some(false))
           buttonCheck(buttonText, continueButtonSelector)
@@ -233,8 +233,8 @@ class RetirementAnnuityControllerISpec extends IntegrationTest with ViewHelpers 
           titleCheck(user.specificExpectedResults.get.expectedTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedParagraphText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedParagraphText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(true))
           buttonCheck(buttonText, continueButtonSelector)
@@ -293,8 +293,8 @@ class RetirementAnnuityControllerISpec extends IntegrationTest with ViewHelpers 
           titleCheck(user.specificExpectedResults.get.expectedErrorTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedParagraphText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(3))
+          textOnPageCheck(user.specificExpectedResults.get.expectedParagraphText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(false))
           buttonCheck(buttonText, continueButtonSelector)

--- a/it/controllers/pensions/paymentsIntoPensions/TotalPaymentsIntoRASControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/TotalPaymentsIntoRASControllerISpec.scala
@@ -60,15 +60,15 @@ class TotalPaymentsIntoRASControllerISpec extends IntegrationTest with BeforeAnd
   )
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > fieldset > legend > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val yesSelector = "#value"
     val noSelector = "#value-no"
-    val pSelector = "#main-content > div > div > form > div > fieldset > legend > p"
-    val isCorrectSelector = "#main-content > div > div > form > div > fieldset > legend > h2"
+    val pSelector = "#main-content > div > div > p"
+    val isCorrectSelector = "#main-content > div > div > form > div > fieldset > legend"
     val tableSelector: (Int, Int) => String = (row, column) =>
-      s"#main-content > div > div > form > div > fieldset > legend > table > tbody > tr:nth-child($row) > td:nth-child($column)"
+      s"#main-content > div > div > table > tbody > tr:nth-child($row) > td:nth-of-type($column)"
   }
 
   trait SpecificExpectedResults {

--- a/it/controllers/pensions/paymentsIntoPensions/WorkplaceAmountControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/WorkplaceAmountControllerISpec.scala
@@ -47,7 +47,7 @@ class WorkplaceAmountControllerISpec extends IntegrationTest with ViewHelpers wi
   }
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > label > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val hintTextSelector = "#amount-hint"
@@ -55,11 +55,11 @@ class WorkplaceAmountControllerISpec extends IntegrationTest with ViewHelpers wi
     val inputSelector = "#amount"
     val expectedErrorHref = "#amount"
 
-    def bulletListSelector(index: Int): String = s"#main-content > div > div > form > div > label > ul > li:nth-child($index)"
+    def bulletListSelector(index: Int): String = s"#main-content > div > div > ul > li:nth-child($index)"
 
-    def insetSpanText(index: Int): String = s"#main-content > div > div > form > div > label > div > span:nth-child($index)"
+    def insetSpanText(index: Int): String = s"#main-content > div > div > div > span:nth-child($index)"
 
-    def paragraphSelector(index: Int): String = s"#main-content > div > div > form > div > label > p:nth-child($index)"
+    def paragraphSelector(index: Int): String = s"#main-content > div > div > p:nth-of-type($index)"
   }
 
   trait CommonExpectedResults {
@@ -173,10 +173,10 @@ class WorkplaceAmountControllerISpec extends IntegrationTest with ViewHelpers wi
           titleCheck(user.specificExpectedResults.get.expectedTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet1, bulletListSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet2, bulletListSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           textOnPageCheck(hintText, hintTextSelector)
           textOnPageCheck(poundPrefixText, poundPrefixSelector)
           inputFieldValueCheck(amountInputName, inputSelector, "")
@@ -206,10 +206,10 @@ class WorkplaceAmountControllerISpec extends IntegrationTest with ViewHelpers wi
           titleCheck(user.specificExpectedResults.get.expectedTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet1, bulletListSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet2, bulletListSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           textOnPageCheck(hintText, hintTextSelector)
           textOnPageCheck(poundPrefixText, poundPrefixSelector)
           inputFieldValueCheck(amountInputName, inputSelector, existingAmount)
@@ -304,10 +304,10 @@ class WorkplaceAmountControllerISpec extends IntegrationTest with ViewHelpers wi
           titleCheck(user.specificExpectedResults.get.expectedErrorTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet1, bulletListSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet2, bulletListSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           textOnPageCheck(hintText, hintTextSelector)
           textOnPageCheck(poundPrefixText, poundPrefixSelector)
           inputFieldValueCheck(amountInputName, inputSelector, amountEmpty)
@@ -342,10 +342,10 @@ class WorkplaceAmountControllerISpec extends IntegrationTest with ViewHelpers wi
           titleCheck(user.specificExpectedResults.get.expectedErrorTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet1, bulletListSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet2, bulletListSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           textOnPageCheck(hintText, hintTextSelector)
           textOnPageCheck(poundPrefixText, poundPrefixSelector)
           inputFieldValueCheck(amountInputName, inputSelector, amountInvalidFormat)
@@ -380,10 +380,10 @@ class WorkplaceAmountControllerISpec extends IntegrationTest with ViewHelpers wi
           titleCheck(user.specificExpectedResults.get.expectedErrorTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(expectedParagraph, paragraphSelector(2))
+          textOnPageCheck(expectedParagraph, paragraphSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet1, bulletListSelector(1))
           textOnPageCheck(user.specificExpectedResults.get.expectedBullet2, bulletListSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedYouCanFindThisOut, paragraphSelector(2))
           textOnPageCheck(hintText, hintTextSelector)
           textOnPageCheck(poundPrefixText, poundPrefixSelector)
           inputFieldValueCheck(amountInputName, inputSelector, amountOverMaximum)

--- a/it/controllers/pensions/paymentsIntoPensions/WorkplacePensionControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/WorkplacePensionControllerISpec.scala
@@ -37,7 +37,7 @@ class WorkplacePensionControllerISpec extends IntegrationTest with ViewHelpers w
   private val taxYearEOY: Int = taxYear - 1
 
   object Selectors {
-    val captionSelector: String = "#main-content > div > div > form > div > fieldset > legend > header > p"
+    val captionSelector: String = "#main-content > div > div > header > p"
     val continueButtonSelector: String = "#continue"
     val formSelector: String = "#main-content > div > div > form"
     val yesSelector = "#value"
@@ -45,7 +45,7 @@ class WorkplacePensionControllerISpec extends IntegrationTest with ViewHelpers w
     val h2Selector: String = s"#main-content > div > div > form > div > fieldset > legend > h2"
     val findOutMoreSelector: String = s"#findOutMore-link"
 
-    def paragraphSelector(index: Int): String = s"#main-content > div > div > form > div > fieldset > legend > p:nth-child($index)"
+    def paragraphSelector(index: Int): String = s"#main-content > div > div > p:nth-of-type($index)"
   }
 
   trait CommonExpectedResults {
@@ -156,9 +156,9 @@ class WorkplacePensionControllerISpec extends IntegrationTest with ViewHelpers w
           titleCheck(user.specificExpectedResults.get.expectedTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedInfoText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedTheseCases, paragraphSelector(3))
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedInfoText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedTheseCases, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(3))
           textOnPageCheck(expectedFindOutMoreText, findOutMoreSelector)
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(false))
@@ -185,9 +185,9 @@ class WorkplacePensionControllerISpec extends IntegrationTest with ViewHelpers w
           titleCheck(user.specificExpectedResults.get.expectedTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedInfoText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedTheseCases, paragraphSelector(3))
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedInfoText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedTheseCases, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(3))
           textOnPageCheck(expectedFindOutMoreText, findOutMoreSelector)
           radioButtonCheck(yesText, 1, checked = Some(true))
           radioButtonCheck(noText, 2, checked = Some(false))
@@ -215,9 +215,9 @@ class WorkplacePensionControllerISpec extends IntegrationTest with ViewHelpers w
           titleCheck(user.specificExpectedResults.get.expectedTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedInfoText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedTheseCases, paragraphSelector(3))
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedInfoText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedTheseCases, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(3))
           textOnPageCheck(expectedFindOutMoreText, findOutMoreSelector)
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(true))
@@ -271,9 +271,9 @@ class WorkplacePensionControllerISpec extends IntegrationTest with ViewHelpers w
           titleCheck(user.specificExpectedResults.get.expectedErrorTitle)
           h1Check(user.specificExpectedResults.get.expectedHeading)
           captionCheck(expectedCaption(taxYearEOY), captionSelector)
-          textOnPageCheck(user.specificExpectedResults.get.expectedInfoText, paragraphSelector(2))
-          textOnPageCheck(user.specificExpectedResults.get.expectedTheseCases, paragraphSelector(3))
-          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(4))
+          textOnPageCheck(user.specificExpectedResults.get.expectedInfoText, paragraphSelector(1))
+          textOnPageCheck(user.specificExpectedResults.get.expectedTheseCases, paragraphSelector(2))
+          textOnPageCheck(user.specificExpectedResults.get.expectedWhereToCheck, paragraphSelector(3))
           radioButtonCheck(yesText, 1, checked = Some(false))
           radioButtonCheck(noText, 2, checked = Some(false))
           buttonCheck(buttonText, continueButtonSelector)


### PR DESCRIPTION
### Description
Move all non-hint text content out of the forms in the Payment into pension Journey(Including H1 and Paragraph text)

Add a link to the relevant story in Jira
[SASS-2483](https://jira.tools.tax.service.gov.uk/browse/SASS-2483)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [x]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [x]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [x]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [x]  Have you addressed warnings where appropriate?
- [x]  Have you rebased against the current version of main?
- [x]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
