### PR TITLE
[SASS-2955] Demo

### DIFF
--- a/it/controllers/pensions/paymentsIntoPensions/ReliefAtSourceOneOffPaymentsControllerISpec.scala
+++ b/it/controllers/pensions/paymentsIntoPensions/ReliefAtSourceOneOffPaymentsControllerISpec.scala
@@ -22,6 +22,8 @@ import builders.PensionsUserDataBuilder
 import builders.UserBuilder._
 import forms.YesNoForm
 import models.mongo.{PensionsCYAModel, PensionsUserData}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 import org.scalatest.BeforeAndAfterEach
 import play.api.http.HeaderNames
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
@@ -29,6 +31,8 @@ import play.api.libs.ws.WSResponse
 import utils.PageUrls.PaymentIntoPensions._
 import utils.PageUrls.fullUrl
 import utils.{IntegrationTest, PensionsDatabaseHelper, ViewHelpers}
+import views.ReliefAtSourceOneOffPaymentsViewSpec.Selectors.formSelector
+import views.ReliefAtSourceOneOffPaymentsViewSpec.{CommonExpectedEN, ExpectedIndividualEN, Selectors}
 
 class ReliefAtSourceOneOffPaymentsControllerISpec extends IntegrationTest with ViewHelpers with BeforeAndAfterEach with PensionsDatabaseHelper {
   private val someRasAmount: BigDecimal = 33.33
@@ -63,6 +67,18 @@ class ReliefAtSourceOneOffPaymentsControllerISpec extends IntegrationTest with V
       "has an OK status" in {
         result.status shouldBe OK
       }
+
+      implicit def document: () => Document = () => Jsoup.parse(result.body)
+
+      titleCheck(ExpectedIndividualEN.expectedTitle)
+      h1Check(ExpectedIndividualEN.expectedHeading)
+      captionCheck(CommonExpectedEN.expectedCaption(taxYearEOY), Selectors.captionSelector)
+      textOnPageCheck(ExpectedIndividualEN.thisIncludes, Selectors.paragraphSelector)
+      radioButtonCheck(CommonExpectedEN.yesText, 1, checked = Some(false))
+      radioButtonCheck(CommonExpectedEN.noText, 2, checked = Some(false))
+      buttonCheck(CommonExpectedEN.buttonText, Selectors.continueButtonSelector)
+      formPostLinkCheck(reliefAtSourceOneOffPaymentsUrl(taxYearEOY), formSelector)
+      welshToggleCheck(isWelsh = false)
     }
 
     "render the one-off payments into relief at source (RAS) pensions question page with 'Yes' pre-filled when CYA data exists" which {

--- a/test/support/AltViewUnitTest.scala
+++ b/test/support/AltViewUnitTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package support
+
+import builders.UserBuilder.aUser
+import config.{AppConfig, MockAppConfig}
+import models.AuthorisationRequest
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import play.api.mvc.AnyContent
+import play.api.test.{FakeRequest, Injecting}
+import uk.gov.hmrc.auth.core.AffinityGroup
+import utils.TestTaxYearHelper
+
+trait AltViewUnitTest extends UnitTest
+  with ViewHelper
+  with GuiceOneAppPerSuite
+  with Injecting
+  with PageUrlsHelpers
+  with TestTaxYearHelper {
+
+  private val fakeRequest = FakeRequest().withHeaders("X-Session-ID" -> aUser.sessionId)
+
+  protected implicit val mockAppConfig: AppConfig = new MockAppConfig().config()
+  protected implicit lazy val messagesApi: MessagesApi = inject[MessagesApi]
+
+  protected lazy val defaultMessages: Messages = messagesApi.preferred(fakeRequest.withHeaders())
+  protected lazy val welshMessages: Messages = messagesApi.preferred(Seq(Lang("cy")))
+
+  protected lazy val individualUserRequest = new AuthorisationRequest[AnyContent](aUser, fakeRequest)
+  protected lazy val agentUserRequest =
+    new AuthorisationRequest[AnyContent](aUser.copy(arn = Some("arn"), affinityGroup = AffinityGroup.Agent.toString), fakeRequest)
+
+  protected def getMessages(isWelsh: Boolean): Messages = if (isWelsh) welshMessages else defaultMessages
+
+  protected def getAuthRequest(isAgent: Boolean): AuthorisationRequest[AnyContent] =
+    if (isAgent) agentUserRequest else individualUserRequest
+}

--- a/test/views/OneOffRASPaymentsAmountViewSpec.scala
+++ b/test/views/OneOffRASPaymentsAmountViewSpec.scala
@@ -31,31 +31,23 @@ import views.html.pensions.paymentsIntoPensions.OneOffRASPaymentsAmountView
 
 class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
 
-  private def amountForm: Form[BigDecimal] = new PaymentsIntoPensionFormProvider().oneOffRASPaymentsAmountForm
-
-  private lazy val viewUnderTest = inject[OneOffRASPaymentsAmountView]
+  private lazy val viewUnderTest: OneOffRASPaymentsAmountView = inject[OneOffRASPaymentsAmountView]
+  private val baseAmountForm: Form[BigDecimal] = new PaymentsIntoPensionFormProvider().oneOffRASPaymentsAmountForm
+  private val rasAmount: BigDecimal = 189.01
 
   "the view" should {
     "render as expected" when {
       "there is no cya data" when {
-
-        val rasAmount: BigDecimal = 189.01
-
-        def render(isWelsh: Boolean)(implicit authRequest: AuthorisationRequest[AnyContent]): Document = {
-          implicit val messages: Messages = getMessages(isWelsh)
-          val htmlFormat = viewUnderTest(amountForm, taxYearEOY, rasAmount)
-          Jsoup.parse(htmlFormat.body)
-        }
-
         "requested by an individual" when {
 
           implicit val authRequest: AuthorisationRequest[AnyContent] = getAuthRequest(isAgent = false)
 
           "the preferred language is English" when {
 
-            implicit val document: Document = render(isWelsh = false)
+            val isWelsh = false
+            implicit val document: Document = render(isWelsh, baseAmountForm)
 
-            verify(isWelsh = false, ExpectedContents(
+            verify(isWelsh, ExpectedContents(
               title = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
               header = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
               caption = s"Payments into pensions for 6 April ${taxYearEOY - 1} to 5 April $taxYearEOY",
@@ -72,9 +64,10 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
 
           "the preferred language is Welsh" when {
 
-            implicit val document: Document = render(isWelsh = true)
+            val isWelsh = true
+            implicit val document: Document = render(isWelsh, baseAmountForm)
 
-            verify(isWelsh = true, ExpectedContents(
+            verify(isWelsh, ExpectedContents(
               title = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
               header = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
               caption = s"Payments into pensions for 6 April ${taxYearEOY - 1} to 5 April $taxYearEOY",
@@ -97,7 +90,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is English" when {
 
             val isWelsh = false
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm)
 
             verify(isWelsh, ExpectedContents(
               title = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -117,7 +110,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is Welsh" when {
 
             val isWelsh = true
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm)
 
             verify(isWelsh, ExpectedContents(
               title = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -139,13 +132,6 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
 
       "there is cya data" when {
 
-        val rasAmount: BigDecimal = 189.01
-
-        def render(isWelsh: Boolean)(implicit authRequest: AuthorisationRequest[AnyContent]): Document = {
-          implicit val messages: Messages = getMessages(isWelsh)
-          val htmlFormat = viewUnderTest(amountForm.fill(999.88), taxYearEOY, rasAmount)
-          Jsoup.parse(htmlFormat.body)
-        }
 
         "requested by an individual" when {
 
@@ -153,9 +139,10 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
 
           "the preferred language is English" when {
 
-            implicit val document: Document = render(isWelsh = false)
+            val isWelsh = false
+            implicit val document: Document = render(isWelsh, baseAmountForm.fill(999.88))
 
-            verify(isWelsh = false, ExpectedContents(
+            verify(isWelsh, ExpectedContents(
               title = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
               header = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
               caption = s"Payments into pensions for 6 April ${taxYearEOY - 1} to 5 April $taxYearEOY",
@@ -172,9 +159,10 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
 
           "the preferred language is Welsh" when {
 
-            implicit val document: Document = render(isWelsh = true)
+            val isWelsh = true
+            implicit val document: Document = render(isWelsh, baseAmountForm.fill(999.88))
 
-            verify(isWelsh = true, ExpectedContents(
+            verify(isWelsh, ExpectedContents(
               title = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
               header = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
               caption = s"Payments into pensions for 6 April ${taxYearEOY - 1} to 5 April $taxYearEOY",
@@ -197,7 +185,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is English" when {
 
             val isWelsh = false
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.fill(999.88))
 
             verify(isWelsh, ExpectedContents(
               title = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -217,7 +205,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is Welsh" when {
 
             val isWelsh = true
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.fill(999.88))
 
             verify(isWelsh, ExpectedContents(
               title = "Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -239,14 +227,6 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
 
       "there is no input entry" when {
 
-        val rasAmount: BigDecimal = 189.01
-
-        def render(isWelsh: Boolean)(implicit authRequest: AuthorisationRequest[AnyContent]): Document = {
-          implicit val messages: Messages = getMessages(isWelsh)
-          val htmlFormat = viewUnderTest(amountForm.bind(Map(AmountForm.amount -> "")), taxYearEOY, rasAmount)
-          Jsoup.parse(htmlFormat.body)
-        }
-
         "requested by an individual" when {
 
           implicit val authRequest: AuthorisationRequest[AnyContent] = getAuthRequest(isAgent = false)
@@ -254,7 +234,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is English" when {
 
             val isWelsh = false
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -274,7 +254,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is Welsh" when {
 
             val isWelsh = true
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -299,7 +279,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is English" when {
 
             val isWelsh = false
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -319,7 +299,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is Welsh" when {
 
             val isWelsh = true
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -340,14 +320,6 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
       }
       "there an invalid format input" when {
 
-        val rasAmount: BigDecimal = 189.01
-
-        def render(isWelsh: Boolean)(implicit authRequest: AuthorisationRequest[AnyContent]): Document = {
-          implicit val messages: Messages = getMessages(isWelsh)
-          val htmlFormat = viewUnderTest(amountForm.bind(Map(AmountForm.amount -> "invalid")), taxYearEOY, rasAmount)
-          Jsoup.parse(htmlFormat.body)
-        }
-
         "requested by an individual" when {
 
           implicit val authRequest: AuthorisationRequest[AnyContent] = getAuthRequest(isAgent = false)
@@ -355,7 +327,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is English" when {
 
             val isWelsh = false
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "invalid")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -375,7 +347,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is Welsh" when {
 
             val isWelsh = true
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "invalid")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -400,7 +372,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is English" when {
 
             val isWelsh = false
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "invalid")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -420,7 +392,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is Welsh" when {
 
             val isWelsh = true
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "invalid")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -440,15 +412,6 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
         }
       }
       "there is an input over maximum allowed value" when {
-
-        val rasAmount: BigDecimal = 189.01
-
-        def render(isWelsh: Boolean)(implicit authRequest: AuthorisationRequest[AnyContent]): Document = {
-          implicit val messages: Messages = getMessages(isWelsh)
-          val htmlFormat = viewUnderTest(amountForm.bind(Map(AmountForm.amount -> "100,000,000,000")), taxYearEOY, rasAmount)
-          Jsoup.parse(htmlFormat.body)
-        }
-
         "requested by an individual" when {
 
           implicit val authRequest: AuthorisationRequest[AnyContent] = getAuthRequest(isAgent = false)
@@ -456,7 +419,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is English" when {
 
             val isWelsh = false
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "100,000,000,000")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -477,7 +440,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is Welsh" when {
 
             val isWelsh = true
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "100,000,000,000")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -502,7 +465,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is English" when {
 
             val isWelsh = false
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "100,000,000,000")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -522,7 +485,7 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
           "the preferred language is Welsh" when {
 
             val isWelsh = true
-            implicit val document: Document = render(isWelsh)
+            implicit val document: Document = render(isWelsh, baseAmountForm.bind(Map(AmountForm.amount -> "100,000,000,000")))
 
             verify(isWelsh, ExpectedContents(
               title = "Error: Total one-off payments into relief at source (RAS) pensions, plus basic rate tax relief",
@@ -589,6 +552,12 @@ class OneOffRASPaymentsAmountViewSpec extends AltViewUnitTest {
       welshToggleCheck(isWelsh)
 
     }
+
+  private def render(isWelsh: Boolean, amountForm: Form[BigDecimal])(implicit authRequest: AuthorisationRequest[AnyContent]): Document = {
+    implicit val messages: Messages = getMessages(isWelsh)
+    val htmlFormat = viewUnderTest(amountForm, taxYearEOY, rasAmount)
+    Jsoup.parse(htmlFormat.body)
+  }
 }
 
 // scalastyle:on magic.number

--- a/test/views/ReliefAtSourceOneOffPaymentsViewSpec.scala
+++ b/test/views/ReliefAtSourceOneOffPaymentsViewSpec.scala
@@ -25,33 +25,18 @@ import play.api.data.Form
 import play.api.i18n.Messages
 import play.api.mvc.AnyContent
 import support.ViewUnitTest
+import views.ReliefAtSourceOneOffPaymentsViewSpec.{CommonExpectedCY, CommonExpectedEN, CommonExpectedResults, ExpectedAgentCY, ExpectedAgentEN, ExpectedIndividualCY, ExpectedIndividualEN, Selectors, SpecificExpectedResults, someRasAmount}
 import views.html.pensions.paymentsIntoPensions.ReliefAtSourceOneOffPaymentsView
 
-class ReliefAtSourceOneOffPaymentsViewSpec extends ViewUnitTest {
+object ReliefAtSourceOneOffPaymentsViewSpec {
 
   private val someRasAmount: BigDecimal = 33.33
-  object Selectors {
-    val captionSelector: String = "#main-content > div > div > header > p"
-    val continueButtonSelector: String = "#continue"
-    val formSelector: String = "#main-content > div > div > form"
-    val yesSelector = "#value"
-    val noSelector = "#value-no"
-    val paragraphSelector: String = "#this-includes"
-  }
 
   trait CommonExpectedResults {
     val expectedCaption: Int => String
     val yesText: String
     val noText: String
     val buttonText: String
-  }
-
-  trait SpecificExpectedResults {
-    val expectedHeading: String
-    val expectedTitle: String
-    val expectedErrorTitle: String
-    val thisIncludes: String
-    val expectedErrorMessage: String
   }
 
   object CommonExpectedEN extends CommonExpectedResults {
@@ -67,6 +52,17 @@ class ReliefAtSourceOneOffPaymentsViewSpec extends ViewUnitTest {
     val noText = "No"
     val buttonText = "Continue"
   }
+
+
+  trait SpecificExpectedResults {
+    val expectedHeading: String
+    val expectedTitle: String
+    val expectedErrorTitle: String
+    val thisIncludes: String
+    val expectedErrorMessage: String
+  }
+
+
 
   object ExpectedIndividualEN extends SpecificExpectedResults {
     val expectedHeading = "Did you make any one-off payments into relief at source (RAS) pensions?"
@@ -108,6 +104,24 @@ class ReliefAtSourceOneOffPaymentsViewSpec extends ViewUnitTest {
     val expectedErrorMessage = "Select yes if your client made one-off payments into RAS pensions"
   }
 
+  object Selectors {
+    val captionSelector: String = "#main-content > div > div > header > p"
+    val continueButtonSelector: String = "#continue"
+    val formSelector: String = "#main-content > div > div > form"
+    val yesSelector = "#value"
+    val noSelector = "#value-no"
+    val paragraphSelector: String = "#this-includes"
+  }
+
+}
+
+class ReliefAtSourceOneOffPaymentsViewSpec extends ViewUnitTest {
+
+
+
+
+
+
   val userScenarios: Seq[UserScenario[CommonExpectedResults, SpecificExpectedResults]] = Seq(
     UserScenario(isWelsh = false, isAgent = false, CommonExpectedEN, Some(ExpectedIndividualEN)),
     UserScenario(isWelsh = false, isAgent = true, CommonExpectedEN, Some(ExpectedAgentEN)),
@@ -125,7 +139,7 @@ class ReliefAtSourceOneOffPaymentsViewSpec extends ViewUnitTest {
         implicit val authRequest: AuthorisationRequest[AnyContent] = getAuthRequest(userScenario.isAgent)
         implicit val messages: Messages = getMessages(userScenario.isWelsh)
 
-        val htmlFormat = underTest(yesNoForm(userScenario.isAgent), taxYearEOY, someRasAmount)
+        val htmlFormat = underTest(yesNoForm(userScenario.isAgent), taxYearEOY, ReliefAtSourceOneOffPaymentsViewSpec.someRasAmount)
 
         implicit val document: Document = Jsoup.parse(htmlFormat.body)
 
@@ -134,7 +148,7 @@ class ReliefAtSourceOneOffPaymentsViewSpec extends ViewUnitTest {
 
         titleCheck(userScenario.specificExpectedResults.get.expectedTitle, userScenario.isWelsh)
         h1Check(userScenario.specificExpectedResults.get.expectedHeading)
-        captionCheck(expectedCaption(taxYearEOY), captionSelector)
+        captionCheck(expectedCaption(taxYearEOY), Selectors.captionSelector)
         textOnPageCheck(userScenario.specificExpectedResults.get.thisIncludes, paragraphSelector)
         radioButtonCheck(yesText, 1, checked = false)
         radioButtonCheck(noText, 2, checked = false)


### PR DESCRIPTION
### Please note that this is only meant for discussion.

If I understand, the main intent is to reduce the running time of the integration tests.

Typically, we have four 'user scenarios' for each: agent or individual, English or Welsh.

With these changes, we reduce the slow integration test to one scenario, and move the four scenarios to unit tests, which assert the generated form in a new way.

My main concern is that the integration test only assesses the status code, and not the form itself; given that we've already paid for the page, it would cost us nothing to assert the form as we used to.

If we did this, then the *Spec would be a realistic test (always with a single user scenario, of course) whereas the companion *ViewSpec would exercise the four (and more, if needed) variations.

And we could share as much as possible - preferably the user scenarios themselves, even keeping the user scenario sequence in the *Spec, but with only one member.

Granted, I didn't attempt this much; but I did show how the form assertions could be restored.

