### PR TITLE
Accessibility - assign paragraph class correctly

### DIFF
--- a/app/views/pensions/annualAllowances/PensionSchemeTaxReferenceView.scala.html
+++ b/app/views/pensions/annualAllowances/PensionSchemeTaxReferenceView.scala.html
@@ -41,7 +41,7 @@
 
 @contentHtml = {
     <p class="govuk-body">@messages(s"common.pensionSchemeTaxReference.p1")</p>
-    <p class="govuk-label govuk-label--m">@messages("common.pensionSchemeTaxReference")</p>
+    <p class="govuk-body">@messages("common.pensionSchemeTaxReference")</p>
 }
 
 

--- a/app/views/pensions/paymentsIntoOverseasPensions/UntaxedEmployerPaymentsView.scala.html
+++ b/app/views/pensions/paymentsIntoOverseasPensions/UntaxedEmployerPaymentsView.scala.html
@@ -63,14 +63,14 @@
     </p>
     <p class="govuk-body">@messages(s"overseasPension.untaxedEmployerPayments.para2.${if(request.user.isAgent) "agent" else "individual"}")</p>
 
-    <div class="govuk-body">
-        <h2 class="govuk-label govuk-label--m" >@messages(s"overseasPension.untaxedEmployerPayments.sub1") </h2>
+    <div class="govuk-form-group">
+        <h2 class="govuk-heading-m" >@messages(s"overseasPension.untaxedEmployerPayments.sub1") </h2>
         <p class="govuk-body">@messages(s"overseasPension.untaxedEmployerPayments.sub1.para1.${if(request.user.isAgent) "agent" else "individual"}")</p>
     </div>
 
 
-    <div class="govuk-body">
-        <h2 class="govuk-label govuk-label--m">@messages(s"overseasPension.untaxedEmployerPayments.sub2") </h2>
+    <div class="govuk-form-group">
+        <h2 class="govuk-heading-m">@messages(s"overseasPension.untaxedEmployerPayments.sub2") </h2>
         <p class="govuk-body">@messages(s"overseasPension.untaxedEmployerPayments.sub2.para1.${if(request.user.isAgent) "agent" else "individual"}")</p>
         @details("overseasPension.untaxedEmployerPayments.sub2.details.title", detailsHtml)
     </div>

--- a/app/views/pensions/unauthorisedPayments/UnauthorisedPaymentsView.scala.html
+++ b/app/views/pensions/unauthorisedPayments/UnauthorisedPaymentsView.scala.html
@@ -60,7 +60,7 @@
     @link("https://www.gov.uk/guidance/pension-schemes-and-unauthorised-payments", "unauthorisedPayments.findOutMoreAboutUnauthorisedPayment", Some("unauthorised-find-out-more-link"), isExternal = false, fullStop = false)
     </p>
 
-    <p class="govuk-label govuk-label--m" id="didYouGetAnUnauthorisedPayment">@messages("unauthorisedPayments.didYouGetAnUnauthorisedPayment")</p>
+    <p class="govuk-body" id="didYouGetAnUnauthorisedPayment">@messages("unauthorisedPayments.didYouGetAnUnauthorisedPayment")</p>
 }
 
 

--- a/app/views/templates/InternalServerErrorTemplate.scala.html
+++ b/app/views/templates/InternalServerErrorTemplate.scala.html
@@ -25,9 +25,9 @@
 
     @heading(messages("internal-server-error-template.heading"), None, "govuk-!-margin-bottom-5", "xl")
 
-    <div class ="govuk-body">
-        <p class=>@messages("internal-server-error-template.paragraph.1")</p>
-        <p class=>@messages("error-template.paragraph.1.1")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages("internal-server-error-template.paragraph.1")</p>
+        <p class="govuk-body">@messages("error-template.paragraph.1.1")</p>
     </div>
 
 

--- a/app/views/templates/NotFoundTemplate.scala.html
+++ b/app/views/templates/NotFoundTemplate.scala.html
@@ -23,11 +23,11 @@
 @layout(pageTitle = messages("not-found-template.heading")) {
     @heading(messages("not-found-template.heading"), None, "govuk-!-margin-bottom-5", "xl")
 
-    <div class="govuk-body">
-        <p>@messages("not-found-template.paragraph.1")</p>
-        <p>@messages("not-found-template.paragraph.2")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages("not-found-template.paragraph.1")</p>
+        <p class="govuk-body">@messages("not-found-template.paragraph.2")</p>
 
-        <p>
+        <p class="govuk-body">
             @messages("common.error.self-assessment.paragraph.1.1")
             <a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/self-assessment" target="_blank"
                id=govuk-self-assessment-link class="govuk-link" rel="noopener noreferrer">@messages("common.error.self-assessment.paragraph.1.2")</a>

--- a/app/views/templates/ServiceUnavailableTemplate.scala.html
+++ b/app/views/templates/ServiceUnavailableTemplate.scala.html
@@ -25,9 +25,9 @@
 
     @heading(messages("service-unavailable-error-template.heading"), None, "govuk-!-margin-bottom-5", "xl")
 
-    <div class="govuk-body">
-        <p>@messages("service-unavailable-error-template.paragraph.1")</p>
-        <p>@messages("error-template.paragraph.1.1")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages("service-unavailable-error-template.paragraph.1")</p>
+        <p class="govuk-body">@messages("error-template.paragraph.1.1")</p>
     </div>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/templates/TaxYearErrorTemplate.scala.html
+++ b/app/views/templates/TaxYearErrorTemplate.scala.html
@@ -23,14 +23,14 @@
 @layout(pageTitle = messages("not-found-template.heading")) {
 @heading(messages("not-found-template.heading"), None, "govuk-!-margin-bottom-5", "xl")
 
-<div class="govuk-body">
+<div class="govuk-form-group">
     @if(singleValidTaxYear)  {
-        <p>@messages("taxYear-error-template.paragraph.1.single")</p>
+        <p class="govuk-body">@messages("taxYear-error-template.paragraph.1.single")</p>
     } else {
-        <p>@messages("taxYear-error-template.paragraph.1", firstClientTaxYear.toString, latestClientTaxYear.toString)</p>
+        <p class="govuk-body">@messages("taxYear-error-template.paragraph.1", firstClientTaxYear.toString, latestClientTaxYear.toString)</p>
     }
-    <p>@messages("taxYear-error-template.paragraph.2")</p>
-    <p>
+    <p class="govuk-body">@messages("taxYear-error-template.paragraph.2")</p>
+    <p class="govuk-body">
         @messages("common.error.self-assessment.paragraph.1.1")
         <a target="_blank" id=govuk-self-assessment-link href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/self-assessment"
            class="govuk-link" rel="noopener noreferrer">@messages("common.error.self-assessment.paragraph.1.2")</a>

--- a/app/views/templates/TimeoutPage.scala.html
+++ b/app/views/templates/TimeoutPage.scala.html
@@ -26,8 +26,8 @@
 
 @heading(messages("timeout.heading"), None, size = "xl", extraClasses = "govuk-!-margin-bottom-5")
 
- <div class="govuk-body">
-     <p>@messages("timeout.p1")</p>
+ <div class="govuk-form-group">
+     <p class="govuk-body">@messages("timeout.p1")</p>
  </div>
 
  @formHelper(postAction) {

--- a/app/views/templates/UnauthorisedUserErrorPageView.scala.html
+++ b/app/views/templates/UnauthorisedUserErrorPageView.scala.html
@@ -24,8 +24,8 @@
 
 @heading(messages("error.unauthorised-user.heading"), None, extraClasses = "govuk-!-margin-bottom-5", size = "xl")
 
-<div class="govuk-body">
-    <p>@messages("error-template.paragraph.1.1a")</p>
+<div class="govuk-form-group">
+    <p class="govuk-body">@messages("error-template.paragraph.1.1a")</p>
 </div>
 
 <ul class="govuk-list govuk-list--bullet">

--- a/test/controllers/predicates/actions/TaxYearActionSpec.scala
+++ b/test/controllers/predicates/actions/TaxYearActionSpec.scala
@@ -90,7 +90,7 @@ class TaxYearActionSpec extends UnitTest with TestTaxYearHelper {
         }
 
         "has the start page redirect url" in {
-          redirectUrl(result.map(_.left.toOption.get)) shouldBe "http://localhost:9302/update-and-submit-income-tax-return/2025/start"
+          redirectUrl(result.map(_.left.toOption.get)) shouldBe "http://localhost:9302/update-and-submit-income-tax-return/2026/start"
         }
 
       }


### PR DESCRIPTION
On several pages the paragraph class has wrongly been assigned to a parent divs and on occasion incorrectly to lists (ul's), causing layout and accessibility issues and as a result seen on pages the following issues:

- empty paragraphs being used to create spacing between block level elements
- additional non standard classes added to div, lists and paragraph to add the missing spacing which comes with using correct classes

Other fixes as part of this wok include:

- fixing broken closing tags for some paragraphs
- missing opening tags for some paragraphs
- removing non standard govuk margins (mostly added most likely as a result of the above issue)
- adding in govuk-form-group - the class design to regulate design and - page flow chunks of content on more complexed pages
- update some illegal labels inside fieldsets to legends
- add in missing govuk-list classes from list
- update failing out of date test